### PR TITLE
Fixed (improved?) checking for catalog duplicates

### DIFF
--- a/library/VMware/VCloud/SDK/Catalog.php
+++ b/library/VMware/VCloud/SDK/Catalog.php
@@ -174,7 +174,7 @@ class VMware_VCloud_SDK_Catalog extends VMware_VCloud_SDK_Abstract
     public function uploadOVFAsVAppTemplate($name, $ovfDescriptorPath, $description=null, $manifestRequired=null, $vdcStorageProfileRef)
     {
         //Check if the resource name is already existing in the catalog.
-        $this->checkCatalogForDuplicates($this, $name);
+        $this->checkCatalogForTemplateDuplicates($this, $name);
 
         //step 1: initial the upload by sending a upload vApp template request
         $vAppTemplate = $this->createVappTemplateRequest($name, $description, $manifestRequired, $vdcStorageProfileRef);
@@ -211,21 +211,53 @@ class VMware_VCloud_SDK_Catalog extends VMware_VCloud_SDK_Abstract
         }
         return $vAppTemp2;
     }
+	
+    /**
+     * Check if the template is already existing in the catalog.
+     * @param VMware_VCloud_SDK_Catalog object  $catalog
+     * @param string $resourceName Name of the vApp template.
+     */
+	public function checkCatalogForTemplateDuplicates($catalog, $resourceName)
+	{
+		return $this->checkCatalogForDuplicates(
+			$catalog,
+			$resourceName,
+			VMware_VCloud_SDK_Constants::VAPP_TEMPLATE_CONTENT_TYPE
+		);
+	}
+	
+    /**
+     * Check if the media is already existing in the catalog.
+     * @param VMware_VCloud_SDK_Catalog object  $catalog
+     * @param string $resourceName Name of the media.
+     */
+	public function checkCatalogForMediaDuplicates($catalog, $resourceName)
+	{
+		return $this->checkCatalogForDuplicates(
+			$catalog,
+			$resourceName,
+			VMware_VCloud_SDK_Constants::MEDIA_CONTENT_TYPE
+		);
+		
+	}
 
     /**
      * Check if the resource name is already existing in the catalog.
      * @param VMware_VCloud_SDK_Catalog object  $catalog
      * @param string $resourceName Name of the vApp template to be created.
+     * @param string $type Type of resource. If empty, type of resource will not be checked.
      * @since API Version 5.5.0
      * @since SDK Version 5.5.0
      */
-    public function checkCatalogForDuplicates($catalog, $resourceName)
+    public function checkCatalogForDuplicates($catalog, $resourceName, $type = "")
     {
         $CatalogItems=$catalog->getCatalogItems();
         foreach ($CatalogItems as $CatalogItem)
         {
-            if($CatalogItem->get_name() == $resourceName)
-            {
+            if (
+				$CatalogItem->get_name() == $resourceName
+				&& (!$type || $CatalogItem->getEntity()->get_type() == $type)
+			) {
                 throw new VMware_VCloud_SDK_Exception (
                           "Duplicate Resource Name Found: $resourceName\n");
             }

--- a/library/VMware/VCloud/SDK/Catalog.php
+++ b/library/VMware/VCloud/SDK/Catalog.php
@@ -216,36 +216,38 @@ class VMware_VCloud_SDK_Catalog extends VMware_VCloud_SDK_Abstract
      * Check if the template is already existing in the catalog.
      * @param VMware_VCloud_SDK_Catalog object  $catalog
      * @param string $resourceName Name of the vApp template.
+     * @return VMware_VCloud_SDK_Catalog
      */
-	public function checkCatalogForTemplateDuplicates($catalog, $resourceName)
-	{
-		return $this->checkCatalogForDuplicates(
-			$catalog,
-			$resourceName,
-			VMware_VCloud_SDK_Constants::VAPP_TEMPLATE_CONTENT_TYPE
-		);
-	}
+    public function checkCatalogForTemplateDuplicates($catalog, $resourceName)
+    {
+        return $this->checkCatalogForDuplicates(
+            $catalog,
+            $resourceName,
+            VMware_VCloud_SDK_Constants::VAPP_TEMPLATE_CONTENT_TYPE
+        );
+    }
 	
     /**
      * Check if the media is already existing in the catalog.
      * @param VMware_VCloud_SDK_Catalog object  $catalog
      * @param string $resourceName Name of the media.
+     * @return VMware_VCloud_SDK_Catalog
      */
-	public function checkCatalogForMediaDuplicates($catalog, $resourceName)
-	{
-		return $this->checkCatalogForDuplicates(
-			$catalog,
-			$resourceName,
-			VMware_VCloud_SDK_Constants::MEDIA_CONTENT_TYPE
-		);
-		
-	}
+    public function checkCatalogForMediaDuplicates($catalog, $resourceName)
+    {
+        return $this->checkCatalogForDuplicates(
+            $catalog,
+            $resourceName,
+            VMware_VCloud_SDK_Constants::MEDIA_CONTENT_TYPE
+        );
+    }
 
     /**
      * Check if the resource name is already existing in the catalog.
      * @param VMware_VCloud_SDK_Catalog object  $catalog
      * @param string $resourceName Name of the vApp template to be created.
      * @param string $type Type of resource. If empty, type of resource will not be checked.
+     * @return VMware_VCloud_SDK_Catalog
      * @since API Version 5.5.0
      * @since SDK Version 5.5.0
      */
@@ -255,11 +257,11 @@ class VMware_VCloud_SDK_Catalog extends VMware_VCloud_SDK_Abstract
         foreach ($CatalogItems as $CatalogItem)
         {
             if (
-				$CatalogItem->get_name() == $resourceName
-				&& (!$type || $CatalogItem->getEntity()->get_type() == $type)
-			) {
+                $CatalogItem->get_name() == $resourceName
+                && (!$type || $CatalogItem->getEntity()->get_type() == $type)
+            ) {
                 throw new VMware_VCloud_SDK_Exception (
-                          "Duplicate Resource Name Found: $resourceName\n");
+                    "Duplicate Resource Name Found: $resourceName\n");
             }
         }
         return $catalog;

--- a/library/VMware/VCloud/SDK/Vdc.php
+++ b/library/VMware/VCloud/SDK/Vdc.php
@@ -212,7 +212,7 @@ class VMware_VCloud_SDK_Vdc extends VMware_VCloud_SDK_Abstract
 $vdcStorageProfileRef, $catalogRef, $onProgress = false)
     {
         //Check if the resource name is already existing in the catalog.
-        $catalog= $this->checkCatalogForDuplicates($catalogRef, $name);
+        $catalog= $this->checkCatalogForTemplateDuplicates($catalogRef, $name);
 
         //step 1: initial the upload by sending a upload vApp template request
         $vAppTemp = $this->sendUploadVAppTemplateRequest($name, 'ovf',
@@ -280,23 +280,56 @@ $vdcStorageProfileRef, $catalogRef, $onProgress = false)
         $this->addResourceToCatalog($vAppTemp2, $catalog);
         return $vAppTemp2->get_href();
     }
+	
+    /**
+     * Check if the template is already existing in the catalog.
+     * @param VMware_VCloud_API_ReferenceType  $catalogRef
+     * @param string $resourceName Name of the vApp template.
+     */
+	public function checkCatalogForTemplateDuplicates($catalogRef, $resourceName)
+	{
+		return $this->checkCatalogForDuplicates(
+			$catalogRef,
+			$resourceName,
+			VMware_VCloud_SDK_Constants::VAPP_TEMPLATE_CONTENT_TYPE
+		);
+	}
+	
+    /**
+     * Check if the media is already existing in the catalog.
+     * @param VMware_VCloud_API_ReferenceType  $catalogRef
+     * @param string $resourceName Name of the media.
+     */
+	public function checkCatalogForMediaDuplicates($catalogRef, $resourceName)
+	{
+		return $this->checkCatalogForDuplicates(
+			$catalogRef,
+			$resourceName,
+			VMware_VCloud_SDK_Constants::MEDIA_CONTENT_TYPE
+		);
+		
+	}
 
     /**
      * Check if the resource name is already existing in the catalog.
      * @param VMware_VCloud_API_ReferenceType  $catalogRef
      * @param string $resourceName Name of the vApp template to be created.
+     * @param string $type Type of resource. If empty, type of resource will not be checked.
      * @since API 1.5 
      * @since SDK 5.1
      */
-    public function checkCatalogForDuplicates($catalogRef, $resourceName)
+    public function checkCatalogForDuplicates($catalogRef, $resourceName, $type = "")
         {
             $catalog=$this->svc->createSDKObj($catalogRef);
             $CatalogItems=$catalog->getCatalogItems();
             foreach ($CatalogItems as $CatalogItem)
             {
-                if($CatalogItem->get_name() == $resourceName)
-                {
-                    echo "Duplicate Resource Name Found: ".$resourceName;
+				if (
+					$CatalogItem->get_name() == $resourceName
+					&& (!$type || $CatalogItem->getEntity()->get_type() == $type)
+				) {
+					throw new VMware_VCloud_SDK_Exception (
+						"Duplicate Resource Name Found: $resourceName\n");
                 }
             }
             return $catalog;

--- a/library/VMware/VCloud/SDK/Vdc.php
+++ b/library/VMware/VCloud/SDK/Vdc.php
@@ -285,29 +285,30 @@ $vdcStorageProfileRef, $catalogRef, $onProgress = false)
      * Check if the template is already existing in the catalog.
      * @param VMware_VCloud_API_ReferenceType  $catalogRef
      * @param string $resourceName Name of the vApp template.
+     * @return VMware_VCloud_SDK_Catalog
      */
-	public function checkCatalogForTemplateDuplicates($catalogRef, $resourceName)
-	{
-		return $this->checkCatalogForDuplicates(
-			$catalogRef,
-			$resourceName,
-			VMware_VCloud_SDK_Constants::VAPP_TEMPLATE_CONTENT_TYPE
-		);
-	}
+    public function checkCatalogForTemplateDuplicates($catalogRef, $resourceName)
+    {
+        return $this->checkCatalogForDuplicates(
+            $catalogRef,
+            $resourceName,
+            VMware_VCloud_SDK_Constants::VAPP_TEMPLATE_CONTENT_TYPE
+        );
+    }
 	
     /**
      * Check if the media is already existing in the catalog.
      * @param VMware_VCloud_API_ReferenceType  $catalogRef
      * @param string $resourceName Name of the media.
+     * @return VMware_VCloud_SDK_Catalog
      */
-	public function checkCatalogForMediaDuplicates($catalogRef, $resourceName)
-	{
-		return $this->checkCatalogForDuplicates(
-			$catalogRef,
-			$resourceName,
-			VMware_VCloud_SDK_Constants::MEDIA_CONTENT_TYPE
-		);
-		
+    public function checkCatalogForMediaDuplicates($catalogRef, $resourceName)
+    {
+        return $this->checkCatalogForDuplicates(
+            $catalogRef,
+            $resourceName,
+            VMware_VCloud_SDK_Constants::MEDIA_CONTENT_TYPE
+        );
 	}
 
     /**
@@ -315,6 +316,7 @@ $vdcStorageProfileRef, $catalogRef, $onProgress = false)
      * @param VMware_VCloud_API_ReferenceType  $catalogRef
      * @param string $resourceName Name of the vApp template to be created.
      * @param string $type Type of resource. If empty, type of resource will not be checked.
+     * @return VMware_VCloud_SDK_Catalog
      * @since API 1.5 
      * @since SDK 5.1
      */
@@ -324,12 +326,12 @@ $vdcStorageProfileRef, $catalogRef, $onProgress = false)
             $CatalogItems=$catalog->getCatalogItems();
             foreach ($CatalogItems as $CatalogItem)
             {
-				if (
-					$CatalogItem->get_name() == $resourceName
-					&& (!$type || $CatalogItem->getEntity()->get_type() == $type)
-				) {
-					throw new VMware_VCloud_SDK_Exception (
-						"Duplicate Resource Name Found: $resourceName\n");
+                if (
+                    $CatalogItem->get_name() == $resourceName
+                    && (!$type || $CatalogItem->getEntity()->get_type() == $type)
+                ) {
+                    throw new VMware_VCloud_SDK_Exception (
+                        "Duplicate Resource Name Found: $resourceName\n");
                 }
             }
             return $catalog;


### PR DESCRIPTION
If you try to upload template with the same name as media item, it will throw an error. The same thing happens if you use WMware vCloud Directory (official software from WMware). Despite this, you can still rename it after upload, so duplicate name on different types does not matter.

I have fixed method which checks for duplicate items - it will now also check type if specified (if not it will work the same way it did). I have adjusted checking duplicates in uploadOVFAsVAppTemplate so it checks only for template duplicates.

Changes were made to both, catalog and vdc.